### PR TITLE
Fix warning during tests

### DIFF
--- a/asipio/application.py
+++ b/asipio/application.py
@@ -39,7 +39,7 @@ class Application(MutableMapping):
                  defaults=None,
                  debug=False,
                  dialplan=BaseDialplan(),
-                 dns_resolver=aiodns.DNSResolver()
+                 dns_resolver=None,
                  ):
 
         if loop is None:
@@ -51,7 +51,7 @@ class Application(MutableMapping):
             self.defaults = DEFAULTS
 
         self.debug = debug
-        self.dns = dns_resolver
+        self.dns = dns_resolver or aiodns.DNSResolver(loop=loop)
         self._finish_callbacks = []
         self._state = {}
         self._dialogs = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,7 +73,7 @@ def test_server(protocol, loop):
 
 
 @pytest.fixture
-async def test_proxy(protocol, loop):
+def test_proxy(protocol, loop):
     servers = []
 
     async def go(handler, **kwargs):


### PR DESCRIPTION
Initialization of the DNSResolver in the default argument is causing Warning of "DeprecationWarning: There is no current event loop", so we change it to None which and handle initialization to happen in the Runtime instead of Class definition, because default arguments are evaluated before the actual class will be initialized. 